### PR TITLE
Make logged messages independent of the Python version

### DIFF
--- a/sbtest
+++ b/sbtest
@@ -34,27 +34,35 @@ def strip_special(line):
 
 
 def run_command(cmd, stdin=None, sudo=False, **kwargs):
-    logging.debug('Running command: %s', cmd)
     if sudo:
-        logging.debug('Sudo command running')
-        cmd = ['sudo'] + cmd
-    logging.debug('Stdin: %s', stdin)
+        cmd.insert(0, 'sudo')
+    logging.debug('Running command: %s', [str(i) for i in cmd])
     p = subprocess.Popen(cmd,
+                         stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          **kwargs)
+
+    if stdin is not None:
+        logging.debug('Stdin: \'%s\'', stdin)
+        stdin = stdin.encode('utf-8')
+
     stdout, stderr = p.communicate(stdin)
     rc = p.wait()
 
+    stdout = stdout.decode('utf-8')
+    logging.debug('Stdout: \'%s\'', stdout)
+
+    stderr = stderr.decode('utf-8')
+    logging.debug('Stderr: \'%s\'', stderr)
+
     logging.debug('Return code: %s', rc)
-    logging.debug('Stdout: %s', stdout)
-    logging.debug('Stderr: %s', stderr)
 
     if rc != 0:
-        raise Exception('Command failed, status: %s, out: %s, err: %s'
+        raise Exception('Command failed, status: %s, out: \'%s\', err: \'%s\''
                         % (rc, stdout, stderr))
 
-    return stdout.decode('utf-8'), stderr.decode('utf-8')
+    return stdout, stderr
 
 
 class LoopDiskManager(object):

--- a/sbtest
+++ b/sbtest
@@ -390,7 +390,7 @@ def perform_expect(commands, sin, sout, print_out):
             raise Exception('Command %s is not a tuple with opcode, arguments' % cmd)
 
         if vmstarted:
-            global_timeout_timer = threading.Timer(10.0, timeout_reached, args=cmd)
+            global_timeout_timer = threading.Timer(20.0, timeout_reached, args=cmd)
             global_timeout_timer.start()
 
         opcode = cmd[0]

--- a/sbtest
+++ b/sbtest
@@ -425,6 +425,12 @@ def perform_expect(commands, sin, sout, print_out):
                 foundneedle = False
                 for needle in needles:
                     if needle in buf:
+                        # Both output sources are enabled
+                        if print_out and logging.getLogger().isEnabledFor(logging.INFO):
+                            # Append '\n' to the output of the QEMU process
+                            print()
+                            # Synchronize the output with logged messages
+                            sys.stdout.flush()
                         logging.debug('Found expected string: \'%s\'', needle.decode('ascii'))
                         foundneedle = True
                         break
@@ -721,6 +727,10 @@ def main():
 
     logging.info('Booting has been fully verified')
 
+    # The output of the QEMU process is the only output source
+    if args.print_output and not logging.getLogger().isEnabledFor(logging.INFO):
+        # Append the trailing '\n' to the output
+        print()
 
 if __name__ == '__main__':
     main()

--- a/sbtest
+++ b/sbtest
@@ -29,8 +29,8 @@ EXIT_CODE_GRUB_ERROR    = 3
 EXIT_CODE_KERN_ERROR    = 4
 
 
-def strip_special(line):
-    return ''.join([c for c in str(line) if c in string.printable])
+def strip_special(text):
+    return ''.join([i for i in text if i in string.printable])
 
 
 def run_command(cmd, stdin=None, sudo=False, **kwargs):
@@ -398,30 +398,34 @@ def perform_expect(commands, sin, sout, print_out):
         commands = commands[1:]
         if opcode == CMD_PRESSKEY:
             assert monitormode, "CMD_PRESSKEY is only valid in monitor mode"
-            key = args[0].encode('ascii')
+            key = args[0]
             repeat = 1
             if len(args) >= 2:
                 repeat = args[1]
             logging.debug('Sending key %s %d times', key, repeat)
+            key = key.encode('ascii')
             while repeat > 0:
                 sin.write(b'sendkey %s\n' % key)
                 sin.flush()
                 repeat -= 1
         elif opcode == CMD_WAIT:
-            needles = [needle.encode('ascii') for needle in args]
-            logging.debug('Waiting for any of %s', needles)
+            needles = args
+            logging.debug('Waiting for any of %s', [str(i) for i in needles])
+            needles = [i.encode('ascii') for i in needles]
             buf = b''
             while True:
                 read = sout.read(1)
                 if len(read) != 1:
                     raise Exception('Error reading')
                 if print_out:
-                    print(strip_special(read), end='')
+                    # The OVMF (EDK II) serial console uses CP437, see:
+                    # MdeModulePkg/Universal/Console/TerminalDxe/TerminalConOut.c
+                    print(strip_special(read.decode('cp437')), end='')
                 buf += read
                 foundneedle = False
                 for needle in needles:
                     if needle in buf:
-                        logging.debug('Found expected string: %s', needle)
+                        logging.debug('Found expected string: \'%s\'', needle.decode('ascii'))
                         foundneedle = True
                         break
                 if foundneedle:
@@ -434,8 +438,9 @@ def perform_expect(commands, sin, sout, print_out):
             logging.log(*args)
         elif opcode == CMD_SENDTEXT:
             assert not monitormode, "CMD_SENDTEXT is only valid in plain text mode"
-            text = args[0].encode('ascii')
-            logging.debug('Sending text %s', text)
+            text = args[0]
+            logging.debug('Sending text \'%s\'', text)
+            text = text.encode('ascii')
             sin.write(text)
             sin.flush()
         elif opcode == CMD_TOGGLEMONITOR:

--- a/sbtest
+++ b/sbtest
@@ -401,7 +401,7 @@ def perform_expect(commands, sin, sout, print_out):
                 repeat -= 1
         elif opcode == CMD_WAIT:
             needles = [needle.encode('ascii') for needle in args]
-            logging.debug('Waiting for any of %s', needle)
+            logging.debug('Waiting for any of %s', needles)
             buf = b''
             while True:
                 read = sout.read(1)

--- a/sbtest
+++ b/sbtest
@@ -166,9 +166,9 @@ def parse_args():
     parser.add_argument('--print-output', help='Print the QEMU guest output',
                         action='store_true')
     parser.add_argument('--verbose', '-v', help='Increase verbosity',
-                        action='count')
+                        action='count', default=0)
     parser.add_argument('--quiet', '-q', help='Decrease verbosity',
-                        action='count')
+                        action='count', default=0)
     parser.add_argument('--qemu-binary', help='QEMU binary path',
                         default='/usr/bin/qemu-system-x86_64')
     parser.add_argument('--enable-kvm', help='Enable KVM acceleration',
@@ -230,15 +230,13 @@ def validate_args(args):
     if args.tpm and not os.path.exists(args.swtpm_path):
         raise SystemExit('SWTPM path invalid')
 
-    verbosity = (args.verbose or 1) - (args.quiet or 0)
-    level = logging.INFO
-    if verbosity >= 2:
-        level = logging.DEBUG
-    elif verbosity == 1:
-        level = logging.INFO
-    elif verbosity < 0:
-        level = logging.ERROR
-    logging.basicConfig(level=level)
+    verbosity = args.verbose - args.quiet
+    logger_level = logging.INFO
+    if verbosity < 0:
+        logger_level = logging.ERROR
+    elif verbosity > 0:
+        logger_level = logging.DEBUG
+    logging.basicConfig(level=logger_level)
 
 
 def generate_keys(args):


### PR DESCRIPTION
The script is compatible with Python 2 and Python 3. However, Python 3 has introduced a difference between text and binary data. Generally, it means that logged messages may vary slightly depending on the version of Python. These commits make logged messages independent of the Python version.

While being there, also fix some small bugs and extend the timeout to 20 seconds.